### PR TITLE
Default options fix.

### DIFF
--- a/components/class-headline-envy-admin.php
+++ b/components/class-headline-envy-admin.php
@@ -110,6 +110,7 @@ class Headline_Envy_Admin {
 
 		$options = $this->sanitize_settings( $data[ $this->core->option_key ] );
 		$options = $this->create_shell_experiment( $options );
+		$options = wp_parse_args( $options, $this->core->get_options() );
 
 		update_option( $this->core->option_key, $options );
 


### PR DESCRIPTION
Small fix so that default options don't get lost when someone enters an API key that fails to validate during initial setup.
